### PR TITLE
xcrun --sdk macosx

### DIFF
--- a/misen.swift
+++ b/misen.swift
@@ -1,4 +1,4 @@
-#!/usr/bin/env xcrun swift
+#!/usr/bin/env xcrun -sdk macosx swift
 
 import Foundation
 


### PR DESCRIPTION
After I added a Run Script Phase that executed misen.swif in an iOS application project, my build began failing due to several shell script Invocation errors and warnings.

The most relevant was:

> using sysroot for 'iPhoneSimulator' but targeting 'MacOSX'

Which made me think that you must specify that you want to use the macosx SDK in order to execute misen.swift.




